### PR TITLE
Align Evaluation with Unfiltered `nq_dev` Split (7,830 Queries)

### DIFF
--- a/src/data/data_prep/nq/process_nq_dataset.py
+++ b/src/data/data_prep/nq/process_nq_dataset.py
@@ -177,9 +177,12 @@ def main():
     nq_all_doc = pd.concat([nq_train, nq_dev], ignore_index=True).drop_duplicates('title').reset_index(drop=True)
     print("Total number of documents:", len(nq_all_doc))
 
-    valid_ids = set(nq_all_doc['id'])
-    nq_train = nq_train[nq_train['id'].isin(valid_ids)]
-    nq_dev = nq_dev[nq_dev['id'].isin(valid_ids)]
+    valid_title = set(nq_all_doc['title'])
+    nq_train = nq_train[nq_train['title'].isin(valid_title)]
+    nq_dev = nq_dev[nq_dev['title'].isin(valid_title)]
+
+    nq_train['id'] = nq_train['title'].map(title_to_id)
+    nq_dev['id'] = nq_dev['title'].map(title_to_id)
 
     os.makedirs(args.output_json_dir, exist_ok=True)
 


### PR DESCRIPTION
### 📋 Description

This PR updates the evaluation setup to align with the **unfiltered `nq_dev` set (7,830 queries)**, based on clarifications from the authors of the referenced paper. The changes aim to ensure **fair comparison** and **reproducibility** across different implementations.

### ✅ Changes

- Removed previous ID-level filtering from the `nq_dev` evaluation set
- Ensured consistency with the **NCI preprocessing pipeline**

### 🤝 Acknowledgements

Special thanks to **Kidist** for the detailed and thoughtful response. I appreciate the openness and effort in clarifying the setup — it has been very helpful for aligning results.