### PR TITLE
Fix return value in run_training_pipeline function

### DIFF
--- a/src/utils/run_training_pipeline.py
+++ b/src/utils/run_training_pipeline.py
@@ -18,7 +18,7 @@ def load_config(encoding: str, scale: str):
 
     config_data["atomic"]["add_doc_num"] = config_data["doc_num"][scale]
     config = config_data[encoding]
-    return config, config_data["doc_num"][scale]
+    return config, config["add_doc_num"][scale]
 
 
 def run_stage(stage_name: str, model: str, load_model: str, all_data: str, cur_data: str,


### PR DESCRIPTION
### Summary
This PR fixes a bug in `load_config` where the returned `add_doc_num` value was always taken from the top-level `config_data["doc_num"]`, causing incorrect behavior when the selected encoding was not `"atomic"`.

### Background
Previously, the function always returned:

```python
return config, config_data["doc_num"][scale]
```

As a result, non-atomic encodings received an incorrect add_doc_num value.

### Fix
The return value is updated to use the encoding-specific field instead:

```python
return config, config["add_doc_num"][scale]
```